### PR TITLE
Fix the marker position issue

### DIFF
--- a/examples/visualize/map.html
+++ b/examples/visualize/map.html
@@ -64,7 +64,7 @@ function getMore() {
 			getMore.lastTimestamp = d[i][0];
 		}
 		var cStr = '<div id="content">';
-		marker.setPosition(nextLatlng);
+		marker.setPosition(myLatlng);
 		var i = d.length - 1; // last spot
 		if (d[i][9] == 'D' || d[i][9] == 'R'){cStr+='going '+d[i][1]+' mph'}
 		else if (d[i][8] < 0){cStr+='parked and charging ~ '+(-d[i][8])+'kW'}


### PR DESCRIPTION
On the map page the marker would occasionally disappear or be in the completely
wrong spot. This was caused by a bug that would potentially reference an
unitialized variable, especially when the car was parked.

Signed-off-by: Dirk Hohndel dirk@hohndel.org
