### PR TITLE
Catch yet another potential charging state

### DIFF
--- a/examples/visualize/visualize.js
+++ b/examples/visualize/visualize.js
@@ -398,6 +398,7 @@ app.get('/energy', function(req, res) {
 							}
 						}
 					} else if (doc.chargeState.charging_state === 'Disconnected' ||
+						   doc.chargeState.charging_state === 'Complete' ||
 						   doc.chargeState.charging_state === 'Starting' ||
 						   doc.chargeState.charging_state === 'Stopped') {
 						outputAmp += ",[" + doc.ts + ",0]";


### PR DESCRIPTION
'Complete' should also be handled like 'Disconnected', not like a missing
sample.

Signed-off-by: Dirk Hohndel dirk@hohndel.org
