### PR TITLE
Update package.json to not use express 4 since visualize.js then breaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "open": "~0.0.3",
     "multimeter-hj": "~0.1.2",
     "mongodb": ">= 1.3.14",
-    "express": ">= 3.3",
+    "express": "= 3.*",
     "passport": ">= 0.1.17",
     "passport-local": ">= 0.1.6"
   },


### PR DESCRIPTION
Tiny fix which allows visualize to continue working now that express 4 is out.
