### PR TITLE
fix: upgrade vulnerable dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.6",
   "description": "Utilities for the Tesla Model S ",
   "dependencies": {
-    "express": "= 3.x",
+    "express": "4.14.0",
     "express-namespace": "~0.1.1",
     "json-bigint": ">= 0.1.4",
     "kerberos": "~0.0",


### PR DESCRIPTION
This pull request fixes a [ReDOS vulnerability](https://snyk.io/vuln/npm:negotiator:20160616) in the `negotiator` dependency, introduced via an outdated version of `express`.

The PR changes `Package.json` to upgrade express to the newer 4.14.0 version, which uses the fixed `negotiator` version 0.6.1, and does not pull in any other vulnerable dependencies.

This vulnerability was identified using [Snyk](https://snyk.io/). 
You can get alerts and fix PRs for future vulnerabilities for free by [registering this repo to be watched by Snyk](https://snyk.io/add).

As this PR includes a major version upgrade, and this repo has no automated tests, please check the changes in this PR to ensure they won't cause issues with your project.

Stay secure,
The Snyk Community
